### PR TITLE
permit setting a default xsession from .xinitrc

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -293,6 +293,9 @@ void Cfg::fillSessionList(){
 
 	sessions.clear();
 
+	pair<string,string> session("","default");
+	sessions.push_back(session);
+
 	if( !strSessionDir.empty() ) {
 		DIR *pDir = opendir(strSessionDir.c_str());
 
@@ -335,11 +338,6 @@ void Cfg::fillSessionList(){
 			}
 			closedir(pDir);
 		}
-	}
-
-	if (sessions.empty()){
-		pair<string,string> session("","");
-		sessions.push_back(session);
 	}
 }
 


### PR DESCRIPTION
Without this patch the order of xsessions is dependent on the order in which `readdir(pDir)` returns them. Thus the default xsession may be quite random.

With this patch one may match for "default" in .xinitrc thus setting the default xsession:

```
case $SESSION in
        gnome-session) exec gnome-session ;;
        icewm-session) exec icewm-session ;;
        xmonad)
                trayer &
                exec xmonad ;;
        wmii | default | *)
                trayer &
                exec wmii ;;
esac
```
