### PR TITLE
Fix evident typo causing build failure.

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -45,7 +45,7 @@ int conv(int num_msg, const struct pam_message **msg,
 
 	for (i = 0; i < num_msg; i++) {
 		(*resp)[i].resp = 0;
-		(*resp)[i].resp_retcodei = 0;
+		(*resp)[i].resp_retcode = 0;
 		switch (msg[i]->msg_style) {
 			case PAM_PROMPT_ECHO_ON:
 				/* We assume PAM is asking for the username */


### PR DESCRIPTION
While testing some modifications to slim I noticed the master branch contains this typo, I just fixed it.
