### PR TITLE
Add option to allow disabling root password check for halt, reboot and suspend.

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -377,7 +377,7 @@ void App::Run()
         if (firstloop)
             LoginPanel->SwitchSession();
 
-		if (!AuthenticateUser(focuspass && firstloop)) {
+		if (!AuthenticateUser(focuspass && firstloop, cfg->getOption("hrsauth") == "true")) {
 			panelclosed = 0;
 			firstloop = false;
 			LoginPanel->ClearPanel();
@@ -421,7 +421,7 @@ void App::Run()
 }
 
 #ifdef USE_PAM
-bool App::AuthenticateUser(bool focuspass)
+bool App::AuthenticateUser(bool focuspass, bool hrsauth)
 {
 	/* Reset the username */
 	try{
@@ -430,6 +430,11 @@ bool App::AuthenticateUser(bool focuspass)
 		pam.authenticate();
 	} catch(PAM::Auth_Exception& e) {
 		switch (LoginPanel->getAction()) {
+			case Panel::Reboot:
+			case Panel::Halt:
+			case Panel::Suspend:
+				if(hrsauth)
+					break;
 			case Panel::Exit:
 			case Panel::Console:
 				return true; /* <--- This is simply fake! */
@@ -468,7 +473,10 @@ bool App::AuthenticateUser(bool focuspass)
 		case Panel::Suspend:
 		case Panel::Halt:
 		case Panel::Reboot:
-			pw = getpwnam("root");
+			if(hrsauth)
+				pw = getpwnam("root");
+			else
+				return true
 			break;
 		case Panel::Console:
 		case Panel::Exit:

--- a/app.h
+++ b/app.h
@@ -63,7 +63,7 @@ private:
 	char *StrConcat(const char *str1, const char *str2);
 	void UpdatePid();
 
-	bool AuthenticateUser(bool focuspass);
+	bool AuthenticateUser(bool focuspass, bool hrsauth);
 
 	static std::string findValidRandomTheme(const std::string &set);
 	static void replaceVariables(std::string &input,

--- a/cfg.cpp
+++ b/cfg.cpp
@@ -39,6 +39,7 @@ Cfg::Cfg()
 	options.insert(option("halt_cmd","/sbin/shutdown -h now"));
 	options.insert(option("reboot_cmd","/sbin/shutdown -r now"));
 	options.insert(option("suspend_cmd",""));
+	options.insert(option("hrsauth", "true"));
 	options.insert(option("sessionstart_cmd",""));
 	options.insert(option("sessionstop_cmd",""));
 	options.insert(option("console_cmd","/usr/bin/xterm -C -fg white -bg black +sb -g %dx%d+%d+%d -fn %dx%d -T ""Console login"" -e /bin/sh -c ""/bin/cat /etc/issue; exec /bin/login"""));


### PR DESCRIPTION
This is more an hack than a real implementation, but I'd like some feedback and maybe this can be made in something that can be included in the official sources.

Thanks!
